### PR TITLE
Allow `psr/container:^2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php": "^7.3 || ~8.0.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-session": "^1.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0|^2.0",
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Only requires new minor version.

See https://github.com/hannesvdvreken/psr-container-v2-demonstrator/pull/1 for an explanation.
