### PR TITLE
make token invalidation optional

### DIFF
--- a/src/CsrfGuardInterface.php
+++ b/src/CsrfGuardInterface.php
@@ -23,5 +23,5 @@ interface CsrfGuardInterface
      *
      * CSRF tokens should EXPIRE after the first hop.
      */
-    public function validateToken(string $token, string $csrfKey = '__csrf'): bool;
+    public function validateToken(string $token, string $csrfKey = '__csrf', bool $invalidateToken = true): bool;
 }

--- a/src/FlashCsrfGuard.php
+++ b/src/FlashCsrfGuard.php
@@ -26,7 +26,7 @@ class FlashCsrfGuard implements CsrfGuardInterface
         return $token;
     }
 
-    public function validateToken(string $token, string $csrfKey = '__csrf'): bool
+    public function validateToken(string $token, string $csrfKey = '__csrf', bool $invalidateToken = true): bool
     {
         $storedToken = $this->flashMessages->getFlash($csrfKey, '');
         return $token === $storedToken;

--- a/src/SessionCsrfGuard.php
+++ b/src/SessionCsrfGuard.php
@@ -26,10 +26,12 @@ class SessionCsrfGuard implements CsrfGuardInterface
         return $token;
     }
 
-    public function validateToken(string $token, string $csrfKey = '__csrf'): bool
+    public function validateToken(string $token, string $csrfKey = '__csrf', bool $invalidateToken = true): bool
     {
         $storedToken = $this->session->get($csrfKey, '');
-        $this->session->unset($csrfKey);
+        if ($invalidateToken) {
+            $this->session->unset($csrfKey);
+        }
         return $token === $storedToken;
     }
 }

--- a/test/SessionCsrfGuardTest.php
+++ b/test/SessionCsrfGuardTest.php
@@ -76,6 +76,17 @@ class SessionCsrfGuardTest extends TestCase
     ): void {
         $this->session->expects(self::atLeastOnce())->method('get')->with($csrfKey, '')->willReturn($sessionTokenValue);
         $this->session->expects(self::atLeastOnce())->method('unset')->with($csrfKey);
-        $this->$assertion($this->guard->validateToken($token, $csrfKey));
+        $this->$assertion($this->guard->validateToken($token, $csrfKey, true));
+    }
+
+    public function testValidateTokenWithoutInvalidatingToken(): void
+    {
+        $csrfKey           = '__csrf';
+        $token             = 'token';
+        $sessionTokenValue = 'token';
+
+        $this->session->expects(self::atLeastOnce())->method('get')->with($csrfKey, '')->willReturn($sessionTokenValue);
+        $this->session->expects(self::never())->method('unset')->with($csrfKey);
+        $this->assertTrue($this->guard->validateToken($token, $csrfKey, false));
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

In my opinion, invalidating a csrf token should be optional. The token is currently invalidated in the src/SessionCsrfGuard::validateToken method with each call. This is not always the desired behaviour. Especially when using the libary in legacy Applications.

References:
https://security.stackexchange.com/questions/22903/why-refresh-csrf-token-per-form-request/22936

> For the reasons already discussed, it is not necessary to generate a new token per request. It brings almost zero security advantage, and it costs you in terms of usability: with only one token valid at once, the user will not be able to navigate the webapp normally. For example if they hit the 'back' button and submit the form with new values, the submission will fail, and likely greet them with some hostile error message. If they try to open a resource in a second tab, they'll find the session randomly breaks in one or both tabs.

https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern

> CSRF tokens should be generated on the server-side. They can be **generated once per user session** or for each request. Per-request tokens are more secure than per-session tokens as the time range for an attacker to exploit the stolen tokens is minimal. **However, this may result in usability concerns. For example, the "Back" button browser capability is often hindered as the previous page may contain a token that is no longer valid. Interaction with this previous page will result in a CSRF false positive security event at the server.** In per-session token implementation after initial generation of token, the value is stored in the session and is used for each subsequent request until the session expires.


<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
